### PR TITLE
Add the correct ContentType depending on the file

### DIFF
--- a/jquery.html5_upload.js
+++ b/jquery.html5_upload.js
@@ -181,7 +181,7 @@
                         builder += '; filename="' + fileName + '"';
                         builder += crlf;
 
-                        builder += 'Content-Type: application/octet-stream';
+                        builder += 'Content-Type: ' + file.type;
                         builder += crlf;
                         builder += crlf;
 


### PR DESCRIPTION
I've change on the headers creation, the ContentType information.
Before the change always put application/octet-stream so I obtain from the uploaded file the correct type and I put it on the builder
