### PR TITLE
fix response status 201-204 triggers onError

### DIFF
--- a/jquery.html5_upload.js
+++ b/jquery.html5_upload.js
@@ -112,7 +112,7 @@
                     options.setProgress(options.genProgress(rpe.loaded, rpe.total));
                 };
                 xhr.onload = function(load) {
-                    if (xhr.status != 200) {
+                    if (!/^2\d\d$/.test(xhr.status)) {
                         $this.triggerHandler('html5_upload.onError', [get_file_name(file), load]);
                         if (!options.stopOnFirstError) {
                             upload_file(number+1);


### PR DESCRIPTION
Previously only status of 200 was considered
success, so 201-204 would trigger onError.
Now use regex test to verify status == /2\d\d/.