### PR TITLE
Allow user to trigger upload start by passing in an HTML5 file drop event

### DIFF
--- a/example.html
+++ b/example.html
@@ -4,9 +4,17 @@
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
         <script src="jquery.html5_upload.js" type="text/javascript"></script>
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+
+        <style>
+            #drop_area.file_hover {
+                background:red;
+            }
+
+        </style>
     </head>
     <body>
         <input type="file" multiple="multiple" id="upload_field" />
+        <div id="drop_area" style="margin:20px 0; width:300px; padding:20px; border:1px dashed black;">or drop file(s) here</div>
         <div id="progress_report">
             <div id="progress_report_name"></div>
             <div id="progress_report_status" style="font-style: italic;"></div>
@@ -16,7 +24,7 @@
         </div>
         <script type="text/javascript">
             $(function() {
-                $("#upload_field").html5_upload({
+                var $input = $("#upload_field").html5_upload({
                     url: function(number) {
                         return prompt(number + " url", "/");
                     },
@@ -44,6 +52,28 @@
                         alert('error while uploading file ' + name);
                     }
                 });
+
+
+
+                // Example of how to use this with a html5 drop event
+                
+                // see http://weblog.bocoup.com/using-datatransfer-with-jquery-events/
+                $.event.props.push('dataTransfer');
+
+                var $drop = $('#drop_area');
+                $drop.on( 'dragover dragenter', function(e){ 
+                    $drop.addClass('file_hover'); 
+                    return false;
+                }).on( 'dragleave dragexit', function(e){ 
+                    $drop.removeClass('file_hover');
+                    return false;
+                }).on( 'drop', function(e){            
+                    if(e.originalEvent.dataTransfer && e.originalEvent.dataTransfer.files.length) {
+                        $input.trigger('html5_upload.startFromDrop', e );
+                    }
+                    return false;
+                })
+
             });
         </script>
     </body>

--- a/example.html
+++ b/example.html
@@ -57,7 +57,7 @@
 
                 // Example of how to use this with a html5 drop event
                 
-                // see http://weblog.bocoup.com/using-datatransfer-with-jquery-events/
+                // this is absolutely necessary -- see http://weblog.bocoup.com/using-datatransfer-with-jquery-events/
                 $.event.props.push('dataTransfer');
 
                 var $drop = $('#drop_area');

--- a/jquery.html5_upload.js
+++ b/jquery.html5_upload.js
@@ -80,7 +80,6 @@
         }, options);
 
         function upload( files ) {
-            console.log( files );
             var total = files.length;
             var $this = $(this);
             if (!$this.triggerHandler('html5_upload.onStart', [total])) {

--- a/jquery.html5_upload.js
+++ b/jquery.html5_upload.js
@@ -1,5 +1,6 @@
 (function($) {
-    jQuery.fn.html5_upload = function(options) {
+    $.fn.html5_upload = function(options) {
+
         function get_file_name(file) {
             return file.name || file.fileName;
         }
@@ -7,7 +8,7 @@
             return file.size || file.fileSize;
         }
         var available_events = ['onStart', 'onStartOne', 'onProgress', 'onFinishOne', 'onFinish', 'onError'];
-        var options = jQuery.extend({
+        var options = $.extend({
             onStart: function(event, total) {
                 return true;
             },
@@ -78,8 +79,8 @@
             }
         }, options);
 
-        function upload() {
-            var files = this.files;
+        function upload( files ) {
+            console.log( files );
             var total = files.length;
             var $this = $(this);
             if (!$this.triggerHandler('html5_upload.onStart', [total])) {
@@ -209,12 +210,15 @@
 
         try {
             return this.each(function() {
+                var file_input = this;
                 this.html5_upload = {
                     xhr:                    new XMLHttpRequest(),
                     continue_after_abort:    true
                 };
                 if (options.autostart) {
-                    $(this).bind('change', upload);
+                    $(this).bind('change', function(e){
+                        upload.call( e.target, this.files );
+                    });
                 }
                 for (event in available_events) {
                     if (options[available_events[event]]) {
@@ -222,6 +226,11 @@
                     }
                 }
                 $(this)
+                    .bind('html5_upload.startFromDrop', function( e, dropEvent ){
+                        if ( dropEvent.dataTransfer && dropEvent.dataTransfer.files.length ){
+                            upload.call( file_input, dropEvent.dataTransfer.files );    
+                        }
+                    })
                     .bind('html5_upload.start', upload)
                     .bind('html5_upload.cancelOne', function() {
                         this.html5_upload['xhr'].abort();


### PR DESCRIPTION
I wanted to use this plugin to handle the uploading part of a drag/drop file upload (like how Gmail attachments work) but the existing code would only begin upload directly from the file input.

I had to refactor slightly, but I tried to keep the core code very simple and not doing too much. This code just letsthe user trigger the upload to start by passing the file drop event itself. 

I've added a clear example in the example.html file that demonstrates how to use this.
