### PR TITLE
Localize scope of 'event' when looping over 'available_events' to fix in...

### DIFF
--- a/jquery.html5_upload.js
+++ b/jquery.html5_upload.js
@@ -216,7 +216,7 @@
                 if (options.autostart) {
                     $(this).bind('change', upload);
                 }
-                for (event in available_events) {
+                for (var event in available_events) {
                     if (options[available_events[event]]) {
                         $(this).bind("html5_upload."+available_events[event], options[available_events[event]]);
                     }


### PR DESCRIPTION
in IE10, unscoped 'event' was null, so no event was bound.
That has lead to triggerHandler returning 'undefined', i.e. for onStart.