### PR TITLE
Fixed encoding problems X-File-Name header

### DIFF
--- a/jquery.html5_upload.js
+++ b/jquery.html5_upload.js
@@ -42,7 +42,7 @@
             headers: {
                 "Cache-Control":"no-cache",
                 "X-Requested-With":"XMLHttpRequest",
-                "X-File-Name": function(file){return get_file_name(file)},
+                "X-File-Name": function(file){return encodeURIComponent(get_file_name(file))},
                 "X-File-Size": function(file){return get_file_size(file)},
                 "X-CSRF-Token": $('meta[name="csrf-token"]').attr("content"),
                 "Content-Type": function(file){


### PR DESCRIPTION
When non-ascii chars are presents in file name, a TypeError exception is thrown.